### PR TITLE
Refactor/paraell proc

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,5 +1,5 @@
 # Agent class for simplicity
-from tools import readFile, processBugReportContent, preprocess_text, load_stopwords, processBugRepotQueryKeyBERT
+from tools import readFile, processBugReportContent, preprocess_text, load_stopwords, processBugReportQueryKeyBERT
 from litellm import completion
 from typing import Callable
 
@@ -29,7 +29,7 @@ Now decide which tool to use.
             elif self.name == "process_bug_report_content_agent":
                 tool_output = self.tools["processBugReportContent"](*args)
             elif self.name == "process_bug_report_query_keybert_agent":
-                tool_output = self.tools["processBugRepotQueryKeyBERT"](*args)
+                tool_output = self.tools["processBugReportQueryKeyBERT"](*args)
             #elif self.name == "source_code_preprocessing_agent":
             #    tool_output = self.tools["source_code_preprocessing"](*args)
             #elif self.name == "hybrid_retrieve_agent":
@@ -69,15 +69,15 @@ try:
         output_key="file_content"
     )
 
-    processBugRepotQueryKeyBERT_agent = Agent(       
+    processBugReportQueryKeyBERT_agent = Agent(       
         model=MY_MODEL,
         name="process_bug_report_query_keybert_agent",          
         instruction="You are the ProcessBugReportQueryKeyBERT Agent."
                     "You will receive the output ('result') of the 'processBugReportContent_agent'."
                     "You will also receive a number ('top_n') which is the number of keywords to extract."
                     "Your ONLY task is to process that content and return it as a string."
-                    "Use the 'processBugRepotQueryKeyBERT' tool to perform this action. ",    
-        tools=[processBugRepotQueryKeyBERT], # List of tools the agent can use
+                    "Use the 'processBugReportQueryKeyBERT' tool to perform this action. ",    
+        tools=[processBugReportQueryKeyBERT], # List of tools the agent can use
         output_key="file_content" # Specify the output key for the tool's result
         )
 except Exception as e:

--- a/main.py
+++ b/main.py
@@ -1,77 +1,100 @@
 import os
-from query_constructions import (
-    load_image_content
-)
+import asyncio
+from query_constructions import load_image_content
 from agents import (
     readBugReportContent_agent,
     processBugReportContent_agent,
-    processBugRepotQueryKeyBERT_agent
+    processBugReportQueryKeyBERT_agent
 )
+read_queue = asyncio.Queue()
+process_queue = asyncio.Queue()
+keybert_queue = asyncio.Queue()
+async def read_worker():
+    '''
+    Reads the content of each bug report (title + description)
+    Once read, the raw text content is passed to the process queue along with bug ID.
+    '''
+    while True:
+        bug_dir, bug_id = await read_queue.get()
+        raw = readBugReportContent_agent.run(bug_dir).get("file_content", "")
+        await process_queue.put((bug_dir, bug_id, raw))
+        read_queue.task_done()
 
-    
+async def process_worker():
+    '''
+    Processes the raw bug report content by cleaning and normalizing the text.
+    Takes (bug_dir, bug_id, raw_text) from process_queue and puts (bug_dir, bug_id, raw, processed) into keybert_queue.
+    '''
+    while True:
+        bug_dir, bug_id, raw = await process_queue.get()
+        processed = processBugReportContent_agent.run(raw).get("file_content", "")
+        await keybert_queue.put((bug_dir, bug_id, raw, processed))
+        process_queue.task_done()
 
-def main_manager(project_id, bug_reports_root, queries_output_root):
-    project_bug_path = os.path.join(bug_reports_root, project_id)
-    project_query_path = os.path.join(queries_output_root, project_id)
-    os.makedirs(project_query_path, exist_ok=True)
-    top_n = 10
-    for bug_id in os.listdir(project_bug_path):
-        bug_dir = os.path.join(project_bug_path, bug_id)
-        if not os.path.isdir(bug_dir):
-            continue
+async def keybert_worker(output_base, top_n):
+    '''
+    Uses KeyBERT to extract keywords from both baseline and extended bug report content.
+    Saves the resulting queries to "baseline_keyBERT_query.txt" and "extended_keyBERT_query.txt" for each bug report.
+    '''
+    while True:
+        bug_dir, bug_id, raw, processed = await keybert_queue.get()
 
-        print(f"\n[INFO] Processing bug {bug_id}...")
-        output_dir = os.path.join(project_query_path, bug_id)
+        keywords = processBugReportQueryKeyBERT_agent.run(processed, top_n).get("file_content", [])
+        baseline_query = " ".join(keywords) if isinstance(keywords, list) else str(keywords)
+
+        output_dir = os.path.join(output_base, bug_id)
         os.makedirs(output_dir, exist_ok=True)
-
-        # === BASELINE QUERY ===
-        # Step 1: Read
-        baseline_raw = readBugReportContent_agent.run(bug_dir).get("file_content", "")
-
-        # Step 2: Process content
-        baseline_processed = processBugReportContent_agent.run(baseline_raw).get("file_content", "")
-
-        # Step 3: generate queries and save
-        baseline_keywords = processBugRepotQueryKeyBERT_agent.run(baseline_processed, top_n).get("file_content", [])
-        if isinstance(baseline_keywords, list):
-            #I need to keep the original query as well
-            #baseline_query = baseline_processed + " " + " ".join(baseline_keywords)
-            #When I only consider the keywords extracted by KeyBERT
-            baseline_query = " ".join(baseline_keywords)
-        else:
-            baseline_query = str(baseline_keywords)
-
         with open(os.path.join(output_dir, "baseline_keyBERT_query.txt"), "w", encoding="utf-8") as f:
             f.write(baseline_query)
 
-        # === EXTENDED QUERY ===
-        # Step 1: Read baseline content + image content
-        extended_raw = baseline_raw + "\n" + load_image_content(bug_dir, bug_id)
-        print(f"[DEBUG] Image content for bug {bug_id}:\n{load_image_content(bug_dir, bug_id)}")
-
-        # Step 2: Process content
+        extended_raw = raw + "\n" + load_image_content(bug_dir, bug_id)
         extended_processed = processBugReportContent_agent.run(extended_raw).get("file_content", "")
-        
-
-        # Step 3: generate queries and save
-        extended_keywords = processBugRepotQueryKeyBERT_agent.run(extended_processed, top_n).get("file_content", [])
-        if isinstance(extended_keywords, list):
-            #I need to keep the original query as well
-            #extended_query = extended_processed + " " + " ".join(extended_keywords)
-            #When I only consider the keywords extracted by KeyBERT
-            extended_query = " ".join(extended_keywords)
-        else:
-            extended_query = str(extended_keywords)
+        extended_keywords = processBugReportQueryKeyBERT_agent.run(extended_processed, top_n).get("file_content", [])
+        extended_query = " ".join(extended_keywords) if isinstance(extended_keywords, list) else str(extended_keywords)
 
         with open(os.path.join(output_dir, "extended_keyBERT_query.txt"), "w", encoding="utf-8") as f:
             f.write(extended_query)
 
-        print(f" Saved: {output_dir}")
+        print(f"Saved: {output_dir}")
+        keybert_queue.task_done()
 
+async def main_async(project_id, bug_reports_root, queries_output_root):
+    '''
+    Main async pipeline controller:
+    - Prepares the input queue with all bug reports in the project.
+    - Starts read, process, and keybert workers in parallel.
+    - And it will wait for all queues to be processed and then shuts down workers.
+    '''
+    top_n = 10
+    bug_path = os.path.join(bug_reports_root, project_id)
+    output_base = os.path.join(queries_output_root, project_id)
+    os.makedirs(output_base, exist_ok=True)
+
+    # Enqueue bug dirs
+    for bug_id in os.listdir(bug_path):
+        bug_dir = os.path.join(bug_path, bug_id)
+        if os.path.isdir(bug_dir):
+            await read_queue.put((bug_dir, bug_id))
+
+    # Start!
+    workers = [
+        asyncio.create_task(read_worker()),
+        asyncio.create_task(process_worker()),
+        asyncio.create_task(keybert_worker(output_base, top_n))
+    ]
+
+    # Wait for all items in the 3 queues to be processed
+    await read_queue.join()
+    await process_queue.join()
+    await keybert_queue.join()
+
+    # Shutdown 
+    for w in workers:
+        w.cancel()
 
 if __name__ == "__main__":
     project_id = "103"
     BugReportPath = os.path.expanduser("./ExampleProjectData/ProjectBugReports/")
     SearchQueryPath = os.path.expanduser("./ExampleProjectData/ConstructedQueries/")
 
-    main_manager(project_id, BugReportPath, SearchQueryPath)
+    asyncio.run(main_async(project_id, BugReportPath, SearchQueryPath))

--- a/tools.py
+++ b/tools.py
@@ -69,7 +69,7 @@ def processBugReportContent(bug_report_content: str) -> str:
     #print(query)
     return query 
 
-def processBugRepotQueryKeyBERT(process_content: str, top_n: int) -> str:
+def processBugReportQueryKeyBERT(process_content: str, top_n: int) -> str:
     """Processes the content of a bug report using KeyBERT and returns it as a string.
 
     Args:


### PR DESCRIPTION
refactor: implement async pipeline for parallel query generation

- Replaced sequential processing with asyncio-based pipeline using three queues
- Introduced read_worker, process_worker, and keybert_worker coroutines
- Each agent now processes input independently and in parallel

Locally tested, seems to produce the same queries, Personally did not notice significant speedup, maybe due to small amount of dataset for now

Another suggestion: We can put all python scripts in the src folder, just make the repo look cleaner and easier to manage in the future when more scripts come in

#5 