### PR TITLE
Fea/parallelprocessing

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,6 +1,6 @@
 # Agent class for simplicity
 from tools import (
-    readFile, processBugReportContent, preprocess_text, load_stopwords, processBugRepotQueryKeyBERT, 
+    readFile, processBugReportContent, preprocess_text, load_stopwords, processBugReportQueryKeyBERT, 
     index_source_code, bug_localization_BM25_and_FAISS, load_index_bm25_and_faiss
 )
 from litellm import completion
@@ -32,7 +32,7 @@ Now decide which tool to use.
             elif self.name == "process_bug_report_content_agent":
                 tool_output = self.tools["processBugReportContent"](*args)
             elif self.name == "process_bug_report_query_keybert_agent":
-                tool_output = self.tools["processBugRepotQueryKeyBERT"](*args)
+                tool_output = self.tools["processBugReportQueryKeyBERT"](*args)
             elif self.name == "index_source_code_agent":
                 tool_output = self.tools["index_source_code"](*args)
             elif self.name == "load_index_bm25_and_faiss_agent":
@@ -76,15 +76,15 @@ try:
         output_key="file_content"
     )
 
-    processBugRepotQueryKeyBERT_agent = Agent(       
+    processBugReportQueryKeyBERT_agent = Agent(       
         model=MY_MODEL,
         name="process_bug_report_query_keybert_agent",          
         instruction="You are the ProcessBugReportQueryKeyBERT Agent."
                     "You will receive the output ('result') of the 'processBugReportContent_agent'."
                     "You will also receive a number ('top_n') which is the number of keywords to extract."
                     "Your ONLY task is to process that content and return it as a string."
-                    "Use the 'processBugRepotQueryKeyBERT' tool to perform this action. ",    
-        tools=[processBugRepotQueryKeyBERT], # List of tools the agent can use
+                    "Use the 'processBugReportQueryKeyBERT' tool to perform this action. ",    
+        tools=[processBugReportQueryKeyBERT], # List of tools the agent can use
         output_key="file_content" # Specify the output key for the tool's result
         )
     

--- a/main.py
+++ b/main.py
@@ -1,9 +1,6 @@
 import os
-import pickle
-from rank_bm25 import BM25Okapi
-from query_constructions import (
-    load_image_content
-)
+import asyncio
+from query_constructions import load_image_content
 from agents import (
     readBugReportContent_agent,
     processBugReportContent_agent,
@@ -13,84 +10,110 @@ from agents import (
     bug_localization_BM25_and_FAISS_agent
 )
 
-    
+# Queues between pipeline stages
+read_queue = asyncio.Queue()
+process_queue = asyncio.Queue()
+keybert_queue = asyncio.Queue()
+localization_queue = asyncio.Queue()
 
-def main_manager(project_id, bug_reports_root, queries_output_root, source_code_dir):
-    project_bug_path = os.path.join(bug_reports_root, project_id)
-    project_query_path = os.path.join(queries_output_root, project_id)
-    os.makedirs(project_query_path, exist_ok=True)
-    top_n = 10
-    count = 0
-    for bug_id in os.listdir(project_bug_path):
-        count += 1
-        if count > 1:
-            break
-        bug_dir = os.path.join(project_bug_path, bug_id)
-        if not os.path.isdir(bug_dir):
-            continue
+# Shared index data
+bm25_index = None
+faiss_index = None
 
-        print(f"\n[INFO] Processing bug {bug_id}...")
-        output_dir = os.path.join(project_query_path, bug_id)
+async def read_worker():
+    '''Reads title + description from bug report folder'''
+    while True:
+        bug_dir, bug_id = await read_queue.get()
+        raw = readBugReportContent_agent.run(bug_dir).get("file_content", "")
+        await process_queue.put((bug_dir, bug_id, raw))
+        read_queue.task_done()
+
+async def process_worker():
+    '''Processes baseline and extended content'''
+    while True:
+        bug_dir, bug_id, raw = await process_queue.get()
+        processed = processBugReportContent_agent.run(raw).get("file_content", "")
+        extended_raw = raw + "\n" + load_image_content(bug_dir, bug_id)
+        extended_processed = processBugReportContent_agent.run(extended_raw).get("file_content", "")
+        await keybert_queue.put((bug_dir, bug_id, processed, extended_processed, raw))
+        process_queue.task_done()
+
+async def keybert_worker(output_base, top_n):
+    '''Extracts keywords for both baseline and extended queries and writes them to disk'''
+    while True:
+        bug_dir, bug_id, baseline_processed, extended_processed, raw = await keybert_queue.get()
+
+        # === Baseline ===
+        keywords = processBugRepotQueryKeyBERT_agent.run(baseline_processed, top_n).get("file_content", [])
+        baseline_query = " ".join(keywords) if isinstance(keywords, list) else str(keywords)
+
+        # === Extended ===
+        extended_keywords = processBugRepotQueryKeyBERT_agent.run(extended_processed, top_n).get("file_content", [])
+        extended_query = " ".join(extended_keywords) if isinstance(extended_keywords, list) else str(extended_keywords)
+
+        output_dir = os.path.join(output_base, bug_id)
         os.makedirs(output_dir, exist_ok=True)
-
-        # === BASELINE QUERY ===
-        # Step 1: Read
-        baseline_raw = readBugReportContent_agent.run(bug_dir).get("file_content", "")
-
-        # Step 2: Process content
-        baseline_processed = processBugReportContent_agent.run(baseline_raw).get("file_content", "")
-
-        # Step 3: generate queries and save
-        baseline_keywords = processBugRepotQueryKeyBERT_agent.run(baseline_processed, top_n).get("file_content", [])
-        if isinstance(baseline_keywords, list):
-            #I need to keep the original query as well
-            #baseline_query = baseline_processed + " " + " ".join(baseline_keywords)
-            #When I only consider the keywords extracted by KeyBERT
-            baseline_query = " ".join(baseline_keywords)
-        else:
-            baseline_query = str(baseline_keywords)
 
         with open(os.path.join(output_dir, "baseline_keyBERT_query.txt"), "w", encoding="utf-8") as f:
             f.write(baseline_query)
-
-        # === EXTENDED QUERY ===
-        # Step 1: Read baseline content + image content
-        extended_raw = baseline_raw + "\n" + load_image_content(bug_dir, bug_id)
-        print(f"[DEBUG] Image content for bug {bug_id}:\n{load_image_content(bug_dir, bug_id)}")
-
-        # Step 2: Process content
-        extended_processed = processBugReportContent_agent.run(extended_raw).get("file_content", "")
-        
-
-        # Step 3: generate queries and save
-        extended_keywords = processBugRepotQueryKeyBERT_agent.run(extended_processed, top_n).get("file_content", [])
-        if isinstance(extended_keywords, list):
-            #I need to keep the original query as well
-            #extended_query = extended_processed + " " + " ".join(extended_keywords)
-            #When I only consider the keywords extracted by KeyBERT
-            extended_query = " ".join(extended_keywords)
-        else:
-            extended_query = str(extended_keywords)
-
         with open(os.path.join(output_dir, "extended_keyBERT_query.txt"), "w", encoding="utf-8") as f:
             f.write(extended_query)
 
         print(f" Saved: {output_dir}")
+        await localization_queue.put((extended_query, bug_id))
+        keybert_queue.task_done()
 
-        # === BUG LOCALIZATION ===
-        # Load BM25 and FAISS indexes
-        bm25_index, faiss_index = load_index_bm25_and_faiss_agent.run("./bm25_index.pkl", "./faiss_index_dir").get("file_content", "")
-      
-        # Localize bug report
+async def localize_worker(top_n):
+    '''Runs BM25+FAISS localization on extended queries'''
+    while True:
+        extended_query, bug_id = await localization_queue.get()
         bug_localization_BM25_and_FAISS_agent.run(extended_query, top_n, bm25_index, faiss_index)
+        print(f" Localized bug {bug_id}")
+        localization_queue.task_done()
 
+async def main_async(project_id, bug_reports_root, queries_output_root, index_paths, top_n=10):
+    global bm25_index, faiss_index
+
+    # Load precomputed indexes 
+    bm25_index, faiss_index = load_index_bm25_and_faiss_agent.run(*index_paths).get("file_content", "")
+
+    bug_path = os.path.join(bug_reports_root, project_id)
+    output_base = os.path.join(queries_output_root, project_id)
+    os.makedirs(output_base, exist_ok=True)
+
+    # Fill read queue with bug IDs
+    for bug_id in os.listdir(bug_path):
+        bug_dir = os.path.join(bug_path, bug_id)
+        if os.path.isdir(bug_dir):
+            await read_queue.put((bug_dir, bug_id))
+
+    # Start
+    workers = [
+        asyncio.create_task(read_worker()),
+        asyncio.create_task(process_worker()),
+        asyncio.create_task(keybert_worker(output_base, top_n)),
+        asyncio.create_task(localize_worker(top_n))
+    ]
+
+    # Wait for all queues to finish
+    await read_queue.join()
+    await process_queue.join()
+    await keybert_queue.join()
+    await localization_queue.join()
+
+    # Finish
+    for w in workers:
+        w.cancel()
 
 if __name__ == "__main__":
     project_id = "103"
     BugReportPath = os.path.expanduser("./ExampleProjectData/ProjectBugReports/")
     SearchQueryPath = os.path.expanduser("./ExampleProjectData/ConstructedQueries/")
     SourceCodeDir = os.path.expanduser("./ExampleProjectData/SourceCodes/Project103/tables/src/")
-    # Index source code
-    index_source_code_agent.run(SourceCodeDir).get("file_content", "")
 
-    main_manager(project_id, BugReportPath, SearchQueryPath, SourceCodeDir)
+    # Generate indexes, I think this optional here if it's precomputed
+    index_source_code_agent.run(SourceCodeDir).get("file_content", "")
+    bm25_path = "./bm25_index.pkl"
+    faiss_path = "./faiss_index_dir"
+
+    asyncio.run(main_async(project_id, BugReportPath, SearchQueryPath, (bm25_path, faiss_path)))

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from query_constructions import load_image_content
 from agents import (
     readBugReportContent_agent,
     processBugReportContent_agent,
-    processBugRepotQueryKeyBERT_agent,
+    processBugReportQueryKeyBERT_agent,
     index_source_code_agent,
     load_index_bm25_and_faiss_agent,
     bug_localization_BM25_and_FAISS_agent
@@ -44,11 +44,11 @@ async def keybert_worker(output_base, top_n):
         bug_dir, bug_id, baseline_processed, extended_processed, raw = await keybert_queue.get()
 
         # === Baseline ===
-        keywords = processBugRepotQueryKeyBERT_agent.run(baseline_processed, top_n).get("file_content", [])
+        keywords = processBugReportQueryKeyBERT_agent.run(baseline_processed, top_n).get("file_content", [])
         baseline_query = " ".join(keywords) if isinstance(keywords, list) else str(keywords)
 
         # === Extended ===
-        extended_keywords = processBugRepotQueryKeyBERT_agent.run(extended_processed, top_n).get("file_content", [])
+        extended_keywords = processBugReportQueryKeyBERT_agent.run(extended_processed, top_n).get("file_content", [])
         extended_query = " ".join(extended_keywords) if isinstance(extended_keywords, list) else str(extended_keywords)
 
         output_dir = os.path.join(output_base, bug_id)

--- a/tools.py
+++ b/tools.py
@@ -75,7 +75,7 @@ def processBugReportContent(bug_report_content: str) -> str:
     #print(query)
     return query 
 
-def processBugRepotQueryKeyBERT(process_content: str, top_n: int) -> str:
+def processBugReportQueryKeyBERT(process_content: str, top_n: int) -> str:
     """Processes the content of a bug report using KeyBERT and returns it as a string.
 
     Args:


### PR DESCRIPTION
feat: add async pipeline for parallel bug localization with BM25 and FAISS

- Implemented asyncio-based parallel processing across four stages:
  - reading bug reports
  - processing and augmenting content
  - generating keyword queries using KeyBERT
  - localizing bugs with BM25 and FAISS indexes
  - Have to change some function params to accomodate the parallel process

suggestion: We can put all python scripts in the src folder, just make the repo look cleaner and easier to manage in the future when more scripts come in